### PR TITLE
chore: promote testreactjx to version 0.0.1

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -2,5 +2,6 @@ filepath: ""
 helmfiles:
 - path: helmfiles/jx/helmfile.yaml
 - path: helmfiles/tekton-pipelines/helmfile.yaml
+- path: helmfiles/jx-staging/helmfile.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -1,0 +1,11 @@
+filepath: ""
+namespace: jx-staging
+repositories:
+- name: dev
+  url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
+releases:
+- chart: dev/testreactjx
+  version: 0.0.1
+  name: testreactjx
+templates: {}
+renderedvalues: {}


### PR DESCRIPTION
chore: promote testreactjx to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
